### PR TITLE
Enable permissive CORS

### DIFF
--- a/opengeo/settings.py
+++ b/opengeo/settings.py
@@ -5,6 +5,7 @@ from typing import Type
 from composed_configuration import (
     ComposedConfiguration,
     ConfigMixin,
+    CorsMixin,
     DevelopmentBaseConfiguration,
     HerokuProductionBaseConfiguration,
     ProductionBaseConfiguration,
@@ -49,7 +50,7 @@ class CrispyFormsMixin(ConfigMixin):
         configuration.INSTALLED_APPS += ['crispy_forms']
 
 
-class OpenGeoMixin(CrispyFormsMixin, GeoDjangoMixin, SwaggerMixin, ConfigMixin):
+class OpenGeoMixin(CrispyFormsMixin, GeoDjangoMixin, SwaggerMixin, CorsMixin, ConfigMixin):
     WSGI_APPLICATION = 'opengeo.wsgi.application'
     ROOT_URLCONF = 'opengeo.urls'
 
@@ -99,6 +100,9 @@ class OpenGeoMixin(CrispyFormsMixin, GeoDjangoMixin, SwaggerMixin, ConfigMixin):
     CELERY_WORKER_SEND_TASK_EVENTS = True
 
     RGD_FILE_FIELD_PREFIX = values.Value(default=None)
+
+    # To use tile endpoints from external origin
+    CORS_ORIGIN_ALLOW_ALL = True
 
 
 class DevelopmentConfiguration(OpenGeoMixin, DevelopmentBaseConfiguration):

--- a/opengeo/settings.py
+++ b/opengeo/settings.py
@@ -101,7 +101,7 @@ class OpenGeoMixin(CrispyFormsMixin, GeoDjangoMixin, SwaggerMixin, CorsMixin, Co
 
     RGD_FILE_FIELD_PREFIX = values.Value(default=None)
 
-    # To use tile endpoints from external origin
+    # To use endpoints from external origin
     CORS_ORIGIN_ALLOW_ALL = True
 
 


### PR DESCRIPTION
In support of https://github.com/ResonantGeoData/RGD-ScrumBoard/issues/32

This should make it so that an external front-end application can use this deployment as the backend