### PR TITLE
Implement Two-Factor Authentication

### DIFF
--- a/opengeo/auth.py
+++ b/opengeo/auth.py
@@ -1,7 +1,13 @@
 from allauth_2fa.adapter import OTPAdapter
+from allauth_2fa.middleware import BaseRequire2FAMiddleware
 from composed_configuration.authentication.adapter import EmailAsUsernameAccountAdapter
 
 
 # composed-configuration already overrides the ACCOUNT_ADAPTER, so we need to subclass it to add 2FA
 class TwoFactorAuthAdapter(OTPAdapter, EmailAsUsernameAccountAdapter):
     pass
+
+
+class RequireTwoFactorAuthMiddleware(BaseRequire2FAMiddleware):
+    def require_2fa(self, request):
+        return True

--- a/opengeo/auth.py
+++ b/opengeo/auth.py
@@ -1,0 +1,7 @@
+from allauth_2fa.adapter import OTPAdapter
+from composed_configuration.authentication.adapter import EmailAsUsernameAccountAdapter
+
+
+# composed-configuration already overrides the ACCOUNT_ADAPTER, so we need to subclass it to add 2FA
+class TwoFactorAuthAdapter(OTPAdapter, EmailAsUsernameAccountAdapter):
+    pass

--- a/opengeo/core/templates/allauth_2fa/backup_tokens.html
+++ b/opengeo/core/templates/allauth_2fa/backup_tokens.html
@@ -1,0 +1,6 @@
+{% extends "allauth_2fa/backup_tokens.html" %}
+
+{% block content %}
+    {{ block.super }}
+    <a style="float: right;" href="/">Go to Home Page</a>
+{% endblock %}

--- a/opengeo/core/templates/base.html
+++ b/opengeo/core/templates/base.html
@@ -1,0 +1,2 @@
+{% extends 'account/base.html' %}
+{% comment %} allauth-2fa expects this file to be present when rendering its default views. {% endcomment %}

--- a/opengeo/settings.py
+++ b/opengeo/settings.py
@@ -77,6 +77,12 @@ class OpenGeoMixin(CrispyFormsMixin, GeoDjangoMixin, SwaggerMixin, ConfigMixin):
             'rgd_fmv',
             'rgd_geometry',
             'rgd_imagery',
+            # Configure the django-otp package.
+            'django_otp',
+            'django_otp.plugins.otp_totp',
+            'django_otp.plugins.otp_static',
+            # Enable two-factor auth.
+            'allauth_2fa',
         ]
 
         configuration.REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'].append(
@@ -99,6 +105,8 @@ class OpenGeoMixin(CrispyFormsMixin, GeoDjangoMixin, SwaggerMixin, ConfigMixin):
     CELERY_WORKER_SEND_TASK_EVENTS = True
 
     RGD_FILE_FIELD_PREFIX = values.Value(default=None)
+
+    ACCOUNT_ADAPTER = 'allauth_2fa.adapter.OTPAdapter'
 
 
 class DevelopmentConfiguration(OpenGeoMixin, DevelopmentBaseConfiguration):

--- a/opengeo/settings.py
+++ b/opengeo/settings.py
@@ -91,6 +91,12 @@ class OpenGeoMixin(CrispyFormsMixin, GeoDjangoMixin, SwaggerMixin, ConfigMixin):
 
         configuration.AUTHENTICATION_BACKENDS.insert(0, 'rules.permissions.ObjectPermissionBackend')
 
+        configuration.MIDDLEWARE += [
+            'django_otp.middleware.OTPMiddleware',
+            'allauth_2fa.middleware.AllauthTwoFactorMiddleware',
+            'opengeo.auth.RequireTwoFactorAuthMiddleware',
+        ]
+
     # This cannot have a default value, since the password and database name are always
     # set by the service admin
     DATABASES = values.DatabaseURLValue(

--- a/opengeo/settings.py
+++ b/opengeo/settings.py
@@ -106,7 +106,7 @@ class OpenGeoMixin(CrispyFormsMixin, GeoDjangoMixin, SwaggerMixin, ConfigMixin):
 
     RGD_FILE_FIELD_PREFIX = values.Value(default=None)
 
-    ACCOUNT_ADAPTER = 'allauth_2fa.adapter.OTPAdapter'
+    ACCOUNT_ADAPTER = 'opengeo.auth.TwoFactorAuthAdapter'
 
 
 class DevelopmentConfiguration(OpenGeoMixin, DevelopmentBaseConfiguration):

--- a/opengeo/urls.py
+++ b/opengeo/urls.py
@@ -2,6 +2,7 @@ import re
 
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.auth.decorators import login_required
 from django.urls import include, path, re_path
 from django.views.generic.base import RedirectView
 from drf_yasg import openapi
@@ -55,6 +56,9 @@ def drf_yasg_get_summary_and_description(self):
 # better with our views.
 SwaggerAutoSchema.get_summary_and_description = drf_yasg_get_summary_and_description
 
+# Require all logins to go through allauth instead of the admin page.
+# This allows us to enforce 2FA even for the admin page.
+admin.site.login = login_required(admin.site.login)
 
 urlpatterns = [
     path('accounts/', include('allauth_2fa.urls')),

--- a/opengeo/urls.py
+++ b/opengeo/urls.py
@@ -57,6 +57,7 @@ SwaggerAutoSchema.get_summary_and_description = drf_yasg_get_summary_and_descrip
 
 
 urlpatterns = [
+    path('accounts/', include('allauth_2fa.urls')),
     path('accounts/', include('allauth.urls')),
     path('oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
     path('admin/', admin.site.urls),

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'django-cleanup',
         'django-crispy-forms',
         'rules',
+        'django-allauth-2fa',
         # Production-only
         'django-composed-configuration[prod]>=0.16',
         'django-s3-file-field[minio]',


### PR DESCRIPTION
This PR adds support for two-factor authentication via an authenticator app (like Google Authenticator).

Resolve https://github.com/ResonantGeoData/RGD-ScrumBoard/issues/37

To use:

- To sign up for 2FA, go to `/accounts/two_factor/setup/` after logging in.
- To generate 2FA backup codes, go to `/accounts/two_factor/backup_tokens/`
- To remove 2FA from an account, go to `/accounts/two_factor/remove`.